### PR TITLE
make pys2let compatible with Cython > 0.27.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,45 @@
-
-import sys
 import os
 import shutil
-
-from distutils.core import setup, Extension
-from Cython.Distutils import build_ext
-from Cython.Build import cythonize
+from distutils.core import Extension, setup
 
 import numpy
+from Cython.Build import cythonize
+from Cython.Distutils import build_ext
 
 # clean previous build
-for root, dirs, files in os.walk('./src/main/python/', topdown=False):
+for root, dirs, files in os.walk("./src/main/python/", topdown=False):
     for name in dirs:
-        if (name == 'build'):
+        if name == "build":
             shutil.rmtree(name)
 
 include_dirs = [
     numpy.get_include(),
-    './include',
-    os.environ['SSHT'] + '/src/c',
-    os.environ['SO3'] + '/src/c'
+    "./include",
+    os.environ["SSHT"] + "/src/c",
+    os.environ["SO3"] + "/src/c",
 ]
 
 extra_link_args = [
-    '-L./build',
-    '-L' + os.environ['FFTW'] + '/lib',
-    # depending whether used cmake
-    '-L' + os.environ['SSHT'] + '/build',
-    '-L' + os.environ['SO3'] + '/build',
-    # or make
-    '-L' + os.environ['SSHT'] + '/lib/c',
-    '-L' + os.environ['SO3'] + '/lib/c'
+    "-L./build",
+    "-L" + os.environ["FFTW"] + "/lib",
+    "-L" + os.environ["SSHT"] + "/build/src/c",
+    "-L" + os.environ["SO3"] + "/build",
+]
+
+extensions = [
+    Extension(
+        "pys2let",
+        sources=["src/main/python/pys2let.pyx"],
+        include_dirs=include_dirs,
+        libraries=["s2let", "so3", "ssht", "fftw3"],
+        extra_link_args=extra_link_args,
+        extra_compile_args=[],
+    )
 ]
 
 setup(
-    name='pys2let',
-    version='2.0',
-    cmdclass={'build_ext': build_ext},
-    ext_modules=cythonize([Extension(
-        'src/main/python/pys2let',
-        sources=['src/main/python/pys2let.pyx'],
-        include_dirs=include_dirs,
-        libraries=['s2let', 'so3', 'ssht', 'fftw3'],
-        extra_link_args=extra_link_args,
-        extra_compile_args=[]
-    )])
+    name="pys2let",
+    version="2.0",
+    cmdclass={"build_ext": build_ext},
+    ext_modules=cythonize(extensions),
 )


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/15052188/86596556-4a3f1500-bf92-11ea-9547-f3d57568d652.png)

after
![image](https://user-images.githubusercontent.com/15052188/86596601-6478f300-bf92-11ea-8583-333696e09a13.png)

essentially the module name in `Extension` changed from `src/main/python/pys2let` to `pys2let`. Also cleaned up `setup.py` a bit.