### PR TITLE
copy s2let_demo5.m and add spin functionality to directional wavelet

### DIFF
--- a/src/main/python/pys2let.pyx
+++ b/src/main/python/pys2let.pyx
@@ -610,9 +610,12 @@ def wavelet_tiling(B, L, N, J_min, spin, original_spin=0):
 	for el from 0 <= el < L:
 		scal_l[el] = phi[el]
 
-	for el from 0 <= el < L*L:
-		for j from J_min <= j <= J:
-			wav_l[el, j-J_min] = psi[ j*L*L + el]
+	for j from 0 <= j <= J - J_min:
+		ind = spin * spin
+		for el from abs(spin) <= el < L:
+			for m from -el <= m <= el:
+				wav_l[ind, j] = psi[(j + J_min) * L * L + ind]
+				ind += 1
 
 	free(psi)
 	free(phi)


### PR DESCRIPTION
making the `wavelet_tiling` equivalent to https://github.com/astro-informatics/src_s2let/blob/master/src/main/matlab/s2let_wavelet_tiling_mex.c

essentially converting this bit
![image](https://user-images.githubusercontent.com/15052188/89025147-3b901780-d31e-11ea-85a6-747ddd556dbb.png)

as per #11 there is still a bug though, this also gets all zero for `psi_lm`