### PR TITLE
SO3 has changed include directory so setup.py updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 import shutil
@@ -10,39 +9,43 @@ from Cython.Build import cythonize
 import numpy
 
 # clean previous build
-for root, dirs, files in os.walk('./src/main/python/', topdown=False):
+for root, dirs, files in os.walk("./src/main/python/", topdown=False):
     for name in dirs:
-        if (name == 'build'):
+        if name == "build":
             shutil.rmtree(name)
 
 include_dirs = [
     numpy.get_include(),
-    './include',
-    os.environ['SSHT'] + '/src/c',
-    os.environ['SO3'] + '/src/c'
+    "./include",
+    os.environ["SSHT"] + "/src/c",
+    os.environ["SO3"] + "/include",
 ]
 
 extra_link_args = [
-    '-L./build',
-    '-L' + os.environ['FFTW'] + '/lib',
+    "-L./build",
+    "-L" + os.environ["FFTW"] + "/lib",
     # depending whether used cmake
-    '-L' + os.environ['SSHT'] + '/build',
-    '-L' + os.environ['SO3'] + '/build',
+    "-L" + os.environ["SSHT"] + "/build",
+    "-L" + os.environ["SO3"] + "/build",
     # or make
-    '-L' + os.environ['SSHT'] + '/lib/c',
-    '-L' + os.environ['SO3'] + '/lib/c'
+    "-L" + os.environ["SSHT"] + "/lib/c",
+    "-L" + os.environ["SO3"] + "/lib/c",
 ]
 
 setup(
-    name='pys2let',
-    version='2.0',
-    cmdclass={'build_ext': build_ext},
-    ext_modules=cythonize([Extension(
-        'src/main/python/pys2let',
-        sources=['src/main/python/pys2let.pyx'],
-        include_dirs=include_dirs,
-        libraries=['s2let', 'so3', 'ssht', 'fftw3'],
-        extra_link_args=extra_link_args,
-        extra_compile_args=[]
-    )])
+    name="pys2let",
+    version="2.0",
+    cmdclass={"build_ext": build_ext},
+    ext_modules=cythonize(
+        [
+            Extension(
+                "src/main/python/pys2let",
+                sources=["src/main/python/pys2let.pyx"],
+                include_dirs=include_dirs,
+                libraries=["s2let", "so3", "ssht", "fftw3"],
+                extra_link_args=extra_link_args,
+                extra_compile_args=[],
+            )
+        ]
+    ),
 )


### PR DESCRIPTION
In response to this PR https://github.com/astro-informatics/src_so3/pull/5 the include directory has changed and hence the `setup.py` needs to change

not to be merged until SO3 has been merged

most of this PR is formatting done by `black`