### PR TITLE
Python wrappers for the adjoint transforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,45 @@
-
-import sys
 import os
 import shutil
-
-from distutils.core import setup, Extension
-from Cython.Distutils import build_ext
-from Cython.Build import cythonize
+from distutils.core import Extension, setup
 
 import numpy
+from Cython.Build import cythonize
+from Cython.Distutils import build_ext
 
 # clean previous build
-for root, dirs, files in os.walk('./src/main/python/', topdown=False):
+for root, dirs, files in os.walk("./src/main/python/", topdown=False):
     for name in dirs:
-        if (name == 'build'):
+        if name == "build":
             shutil.rmtree(name)
 
 include_dirs = [
     numpy.get_include(),
-    './include',
-    os.environ['SSHT'] + '/src/c',
-    os.environ['SO3'] + '/src/c'
+    "./include",
+    os.environ["SSHT"] + "/src/c",
+    os.environ["SO3"] + "/src/c",
 ]
 
 extra_link_args = [
-    '-L./build',
-    '-L' + os.environ['FFTW'] + '/lib',
-    # depending whether used cmake
-    '-L' + os.environ['SSHT'] + '/build',
-    '-L' + os.environ['SO3'] + '/build',
-    # or make
-    '-L' + os.environ['SSHT'] + '/lib/c',
-    '-L' + os.environ['SO3'] + '/lib/c'
+    "-L./build",
+    "-L" + os.environ["FFTW"] + "/lib",
+    "-L" + os.environ["SSHT"] + "/build/src/c",
+    "-L" + os.environ["SO3"] + "/build",
+]
+
+extensions = [
+    Extension(
+        "pys2let",
+        sources=["src/main/python/pys2let.pyx"],
+        include_dirs=include_dirs,
+        libraries=["s2let", "so3", "ssht", "fftw3"],
+        extra_link_args=extra_link_args,
+        extra_compile_args=[],
+    )
 ]
 
 setup(
-    name='pys2let',
-    version='2.0',
-    cmdclass={'build_ext': build_ext},
-    ext_modules=cythonize([Extension(
-        'src/main/python/pys2let',
-        sources=['src/main/python/pys2let.pyx'],
-        include_dirs=include_dirs,
-        libraries=['s2let', 'so3', 'ssht', 'fftw3'],
-        extra_link_args=extra_link_args,
-        extra_compile_args=[]
-    )])
+    name="pys2let",
+    version="2.0",
+    cmdclass={"build_ext": build_ext},
+    ext_modules=cythonize(extensions),
 )

--- a/src/main/python/pys2let.pyx
+++ b/src/main/python/pys2let.pyx
@@ -179,6 +179,32 @@ cdef extern from "s2let.h":
 		double complex*f_scal,
 		const double complex*f,
 		const s2let_parameters_t *parameters)
+
+	void s2let_analysis_px2wav(
+		double complex *f_wav,
+		double complex *f_scal,
+		const double complex *f,
+		const s2let_parameters_t *parameters
+	)
+
+	void s2let_analysis_adjoint_wav2px( 
+		double complex *f,
+		const double complex *f_wav,
+		const double complex *f_scal,
+		const s2let_parameters_t *parameters)
+
+	void s2let_synthesis_wav2px(
+		double complex *flm,
+		const double complex *f_wav,
+		const double complex *f_scal,
+		const s2let_parameters_t *parameters
+	)
+
+	void s2let_synthesis_adjoint_px2wav(
+		double complex *f_wav,
+		double complex *f_scal,
+		const double complex *f,
+		const s2let_parameters_t *parameters)
 #----------------------------------------------------------------------------------------------------#
 
 cdef extern from "stdlib.h":
@@ -599,6 +625,122 @@ def synthesis_wav2lm(
 	f_lm_hp = lm2lm_hp(f_lm, L)
 
 	return f_lm_hp
+
+#----------------------------------------------------------------------------------------------------#
+
+def analysis_px2wav(
+		np.ndarray[double complex, ndim=1, mode="c"] f not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+
+	f_scal = np.zeros([s2let_n_scal(&parameters),], dtype=complex)
+	f_wav = np.zeros([s2let_n_wav(&parameters),], dtype=complex)
+
+	s2let_analysis_px2wav(
+		<double complex*> np.PyArray_DATA(f_wav),
+		<double complex*> np.PyArray_DATA(f_scal),
+		<const double complex*> np.PyArray_DATA(f),
+		&parameters)
+
+	return f_wav, f_scal
+
+#----------------------------------------------------------------------------------------------------#
+
+def analysis_adjoint_wav2px(np.ndarray[double complex, ndim=1, mode="c"] f_wav not None,
+		np.ndarray[double complex, ndim=1, mode="c"] f_scal not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+
+	f = np.zeros([mw_size(L),], dtype=complex)
+	s2let_analysis_adjoint_wav2px(
+		<double complex*> np.PyArray_DATA(f),
+		<const double complex*> np.PyArray_DATA(f_wav),
+		<const double complex*> np.PyArray_DATA(f_scal),
+		&parameters)
+
+	return f
+
+#----------------------------------------------------------------------------------------------------#
+
+def synthesis_wav2px(
+		np.ndarray[double complex, ndim=1, mode="c"] f_wav not None,
+		np.ndarray[double complex, ndim=1, mode="c"] f_scal not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+
+	f = np.zeros([mw_size(L),], dtype=complex)
+	s2let_synthesis_wav2px(
+		<double complex*> np.PyArray_DATA(f),
+		<const double complex*> np.PyArray_DATA(f_wav),
+		<const double complex*> np.PyArray_DATA(f_scal),
+		&parameters)
+
+	return f
+#----------------------------------------------------------------------------------------------------#
+
+def synthesis_adjoint_px2wav(
+		np.ndarray[double complex, ndim=1, mode="c"] f not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+
+	f_scal = np.zeros([s2let_n_scal(&parameters),], dtype=complex)
+	f_wav = np.zeros([s2let_n_wav(&parameters),], dtype=complex)
+
+	s2let_synthesis_adjoint_px2wav(
+		<double complex*> np.PyArray_DATA(f_wav),
+		<double complex*> np.PyArray_DATA(f_scal),
+		<const double complex*> np.PyArray_DATA(f),
+		&parameters)
+
+	return f_wav, f_scal
 
 #----------------------------------------------------------------------------------------------------#
 

--- a/src/main/python/pys2let.pyx
+++ b/src/main/python/pys2let.pyx
@@ -156,6 +156,29 @@ cdef extern from "s2let.h":
 		int reality
 		int verbosity
 
+	void s2let_transform_axisym_wav_synthesis_mw(
+		double complex *f,
+		const double complex *f_wav,
+		const double complex *f_scal,
+		const s2let_parameters_t *parameters)
+
+	void s2let_transform_axisym_wav_analysis_mw(
+		double complex *f_wav,
+		double complex *f_scal,
+		const double complex *f,
+		const s2let_parameters_t *parameters)
+
+	void s2let_transform_axisym_wav_analysis_adjoint_mw(
+		double complex*f,
+		const double complex*f_wav,
+		const double complex*f_scal,
+		const s2let_parameters_t* parameters)
+
+	void s2let_transform_axisym_wav_synthesis_adjoint_mw(
+		double complex*f_wav,
+		double complex*f_scal,
+		const double complex*f,
+		const s2let_parameters_t *parameters)
 #----------------------------------------------------------------------------------------------------#
 
 cdef extern from "stdlib.h":
@@ -222,6 +245,53 @@ def analysis_axisym_lm_wav(
 
 #----------------------------------------------------------------------------------------------------#
 
+def analysis_axisym_wav_mw(
+	np.ndarray[double complex, ndim=1, mode="c"] f not None, B, L, J_min, spin_lowered = False
+):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	J = s2let_j_max(&parameters)
+
+	f_wav = np.zeros(mw_size(L) * (J - J_min + 1), dtype=np.complex)
+	f_scal = np.zeros(mw_size(L), dtype=np.complex)
+
+	s2let_transform_axisym_wav_analysis_mw(
+		<double complex*> np.PyArray_DATA(f_wav),
+		<double complex*> np.PyArray_DATA(f_scal),
+		<double complex*> np.PyArray_DATA(f),
+		&parameters
+	)
+
+	return f_wav, f_scal
+
+#----------------------------------------------------------------------------------------------------#
+
+def analysis_adjoint_axisym_wav_mw(
+	np.ndarray[double complex, ndim=1, mode="c"] f_wav not None,
+	np.ndarray[double complex, ndim=1, mode="c"] f_scal not None, B, L, J_min, spin_lowered = False):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	J = s2let_j_max(&parameters)
+
+	f = np.zeros([L * (2 * L - 1),], dtype=np.complex)
+	s2let_transform_axisym_wav_analysis_adjoint_mw(
+		<double complex*> np.PyArray_DATA(f),
+		<double complex*> np.PyArray_DATA(f_wav),
+		<double complex*> np.PyArray_DATA(f_scal),
+		&parameters
+	)
+
+	return f
+
+
+#----------------------------------------------------------------------------------------------------#
+
 def synthesis_axisym_lm_wav(
 	np.ndarray[double complex, ndim=2, mode="c"] f_wav_lm_hp not None,
 	np.ndarray[double complex, ndim=1, mode="c"] f_scal_lm_hp not None, B, L, J_min, spin_lowered = False):
@@ -260,6 +330,50 @@ def synthesis_axisym_lm_wav(
 	f_lm_hp = lm2lm_hp(f_lm, L)
 
 	return f_lm_hp
+
+#----------------------------------------------------------------------------------------------------#
+
+def synthesis_axisym_wav_mw(
+	np.ndarray[double complex, ndim=1, mode="c"] f_wav not None,
+	np.ndarray[double complex, ndim=1, mode="c"] f_scal not None, B, L, J_min, spin_lowered = False):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	J = s2let_j_max(&parameters)
+
+	f = np.zeros(mw_size(L), dtype=np.complex)
+	s2let_transform_axisym_wav_synthesis_mw(
+		<double complex*> np.PyArray_DATA(f),
+		<double complex*> np.PyArray_DATA(f_wav),
+		<double complex*> np.PyArray_DATA(f_scal),
+		&parameters
+	)
+
+	return f
+
+#----------------------------------------------------------------------------------------------------#
+def synthesis_adjoint_axisym_wav_mw(
+	np.ndarray[double complex, ndim=1, mode="c"] f not None, 
+	B, L, J_min, spin_lowered = False):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	J = s2let_j_max(&parameters)
+
+	f_scal = np.zeros([L * (2 * L - 1),], dtype=np.complex)
+	f_wav = np.zeros([L * (2 * L - 1) * (J - J_min + 1)], dtype=np.complex)
+	s2let_transform_axisym_wav_synthesis_adjoint_mw(
+		<double complex*> np.PyArray_DATA(f_wav),
+		<double complex*> np.PyArray_DATA(f_scal),		
+		<double complex*> np.PyArray_DATA(f),
+		&parameters
+	)
+
+	return f_wav, f_scal
 
 #----------------------------------------------------------------------------------------------------#
 

--- a/src/main/python/pys2let_test_axisym_adjoints.py
+++ b/src/main/python/pys2let_test_axisym_adjoints.py
@@ -17,21 +17,6 @@ B = 2
 J_min = 2
 nwvlts = pys2let_j_max(B, L, J_min) - J_min + 1
 
-#### as in s2let_test.c
-f = random_mw_map(L)
-f_rec = random_mw_map(L)
-
-f_wav, f_scal = analysis_axisym_wav_mw(f, B, L, J_min)
-f_wav_rec, f_scal_rec = analysis_axisym_wav_mw(f_rec, B, L, J_min)
-
-f_rec = analysis_adjoint_axisym_wav_mw(f_wav, f_scal, B, L, J_min)
-
-dot_product_error = f_wav_rec.conj().dot(f_wav)
-dot_product_error += f_scal_rec.conj().dot(f_scal)
-dot_product_error -= f_rec.conj().dot(f)
-
-print(f"Dot product error: {dot_product_error}")
-
 #### as on website http://sepwww.stanford.edu/sep/prof/pvi/conj/paper_html/node9.html
 x = random_mw_map(L)
 y_scal, y_wav = random_wavlet_maps(L, nwvlts)

--- a/src/main/python/pys2let_test_axisym_adjoints.py
+++ b/src/main/python/pys2let_test_axisym_adjoints.py
@@ -1,0 +1,56 @@
+from pys2let import *
+import numpy as np
+
+def random_lms(L):
+    return np.random.rand(L * L).astype(np.complex)
+
+def random_mw_map(L):
+    return alm2map_mw(random_lms(L), L, 0)
+
+def random_wavlet_maps(L, nwvlts):
+    f_scal = random_mw_map(L)
+    f_wav = np.concatenate([random_mw_map(L) for _ in range(nwvlts)])
+    return f_scal, f_wav
+
+L = 10
+B = 2
+J_min = 2
+nwvlts = pys2let_j_max(B, L, J_min) - J_min + 1
+
+#### as in s2let_test.c
+f = random_mw_map(L)
+f_rec = random_mw_map(L)
+
+f_wav, f_scal = analysis_axisym_wav_mw(f, B, L, J_min)
+f_wav_rec, f_scal_rec = analysis_axisym_wav_mw(f_rec, B, L, J_min)
+
+f_rec = analysis_adjoint_axisym_wav_mw(f_wav, f_scal, B, L, J_min)
+
+dot_product_error = f_wav_rec.conj().dot(f_wav)
+dot_product_error += f_scal_rec.conj().dot(f_scal)
+dot_product_error -= f_rec.conj().dot(f)
+
+print(f"Dot product error: {dot_product_error}")
+
+#### as on website http://sepwww.stanford.edu/sep/prof/pvi/conj/paper_html/node9.html
+x = random_mw_map(L)
+y_scal, y_wav = random_wavlet_maps(L, nwvlts)
+
+y = analysis_adjoint_axisym_wav_mw(y_wav, y_scal, B, L, J_min)
+x_wav, x_scal = analysis_axisym_wav_mw(x, B, L, J_min)
+
+dot_product_error = y_wav.conj().dot(x_wav)
+dot_product_error += y_scal.conj().dot(x_scal)
+dot_product_error -= y.conj().dot(x)
+print(f"ANALYSIS Dot product error: {dot_product_error}")
+
+x_scal, x_wav = random_wavlet_maps(L, nwvlts)
+y = random_mw_map(L)
+
+x = synthesis_axisym_wav_mw(x_wav, x_scal, B, L, J_min)
+y_wav, y_scal = synthesis_adjoint_axisym_wav_mw(y, B, L, J_min)
+
+dot_product_error = y.conj().dot(x)
+dot_product_error -= y_wav.conj().dot(x_wav)
+dot_product_error -= y_scal.conj().dot(x_scal)
+print(f"SYNTHESIS Dot product error: {dot_product_error}")

--- a/src/main/python/pys2let_test_directional_adjoints.py
+++ b/src/main/python/pys2let_test_directional_adjoints.py
@@ -1,0 +1,49 @@
+from pys2let import *
+import numpy as np
+
+
+def random_lms(L):
+    return np.random.rand(L * L).astype(np.complex)
+
+
+def random_mw_map(L, spin):
+    return alm2map_mw(random_lms(L), L, spin)
+
+
+def random_wavlet_maps(L, spin, nwvlts):
+    f_scal = random_mw_map(L, spin)
+    f_wav = np.concatenate([random_mw_map(L, spin) for _ in range(nwvlts)])
+    return f_scal, f_wav
+
+
+L = 10
+B = 2
+J_min = 2
+N = 1
+spin = 0
+upsample = 1
+nwvlts = pys2let_j_max(B, L, J_min) - J_min + 1
+
+
+#### as on website http://sepwww.stanford.edu/sep/prof/pvi/conj/paper_html/node9.html
+x = random_mw_map(L, spin)
+y_scal, y_wav = random_wavlet_maps(L, spin, nwvlts)
+
+y = analysis_adjoint_wav2px(y_wav, y_scal, B, L, J_min, N, spin, upsample)
+x_wav, x_scal = analysis_px2wav(x, B, L, J_min, N, spin, upsample)
+
+dot_product_error = y_wav.conj().dot(x_wav)
+dot_product_error += y_scal.conj().dot(x_scal)
+dot_product_error -= y.conj().dot(x)
+print(f"ANALYSIS Dot product error: {dot_product_error}")
+
+x_scal, x_wav = random_wavlet_maps(L, spin, nwvlts)
+y = random_mw_map(L, spin)
+
+x = synthesis_wav2px(x_wav, x_scal, B, L, J_min, N, spin, upsample)
+y_wav, y_scal = synthesis_adjoint_px2wav(y, B, L, J_min, N, spin, upsample)
+
+dot_product_error = y.conj().dot(x)
+dot_product_error -= y_wav.conj().dot(x_wav)
+dot_product_error -= y_scal.conj().dot(x_scal)
+print(f"SYNTHESIS Dot product error: {dot_product_error}")


### PR DESCRIPTION
Python wrappers for the adjoint transforms.  These have been written for both directional and axisymmetric wavelets from pixel to wavelet space (and vice versa).  Wrappers for the same transforms but only in harmonic space should be quick to do for the directional wavelets, but for the axisymmetric the corresponding C functions don't exist and so would require a bit more work