### PR TITLE
Python harmonic

### DIFF
--- a/src/main/pys2let/pys2let.pyx
+++ b/src/main/pys2let/pys2let.pyx
@@ -62,8 +62,8 @@ cdef extern from "s2let/s2let.h":
 	int s2let_n_scal(const s2let_parameters_t *parameters)
 	int s2let_n_wav(const s2let_parameters_t *parameters)
 
-    int s2let_n_lm_scal(const s2let_parameters_t *parameters)
-    int s2let_n_lmn_wav(const s2let_parameters_t *parameters)
+	int s2let_n_lm_scal(const s2let_parameters_t *parameters)
+	int s2let_n_lmn_wav(const s2let_parameters_t *parameters)
 
 	int s2let_n_wav_j(int j, const s2let_parameters_t *parameters)
 
@@ -209,37 +209,37 @@ cdef extern from "s2let/s2let.h":
 		const double complex *f,
 		const s2let_parameters_t *parameters)
 
-    void s2let_analysis_lm2lmn(
-        double complex *f_wav_lmn,
-        double complex *f_scal_lm,
-        const double complex *flm,
-        const double complex *wav_lm,
-        const double *scal_l,
-        const s2let_parameters_t *parameters)
+	void s2let_analysis_lm2lmn(
+		double complex *f_wav_lmn,
+		double complex *f_scal_lm,
+		const double complex *flm,
+		const double complex *wav_lm,
+		const double *scal_l,
+		const s2let_parameters_t *parameters)
 
-    void s2let_analysis_adjoint_lmn2lm(
-        double complex *flm,
-        const double complex *f_wav_lmn,
-        const double complex *f_scal_lm,
-        const double complex *wav_lm,
-        const double *scal_l,
-        const s2let_parameters_t *parameters)
+	void s2let_analysis_adjoint_lmn2lm(
+		double complex *flm,
+		const double complex *f_wav_lmn,
+		const double complex *f_scal_lm,
+		const double complex *wav_lm,
+		const double *scal_l,
+		const s2let_parameters_t *parameters)
 
-    void s2let_synthesis_lmn2lm(
-        double complex *flm,
-        const double complex *f_wav_lmn,
-        const double complex *f_scal_lm,
-        const double complex *wav_lm,
-        const double *scal_l,
-        const s2let_parameters_t *parameters)
+	void s2let_synthesis_lmn2lm(
+		double complex *flm,
+		const double complex *f_wav_lmn,
+		const double complex *f_scal_lm,
+		const double complex *wav_lm,
+		const double *scal_l,
+		const s2let_parameters_t *parameters)
 
-    void s2let_synthesis_adjoint_lm2lmn(
-        double complex *f_wav_lmn,
-        double complex *f_scal_lm,
-        const double complex *flm,
-        const double complex *wav_lm,
-        const double *scal_l,
-        const s2let_parameters_t *parameters)
+	void s2let_synthesis_adjoint_lm2lmn(
+		double complex *f_wav_lmn,
+		double complex *f_scal_lm,
+		const double complex *flm,
+		const double complex *wav_lm,
+		const double *scal_l,
+		const s2let_parameters_t *parameters)
 
 #----------------------------------------------------------------------------------------------------#
 
@@ -795,20 +795,20 @@ def analysis_lm2lmn(np.ndarray[double complex, ndim=1, mode="c"] flm not None,
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-    J = s2let_j_max(parameters)
+	J = s2let_j_max(parameters)
 
 	scal_l = np.zeros([L,])
-    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-                         <double complex*> np.PyArray_DATA(scal_l),
-                          parameters)
+	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+						 <double complex*> np.PyArray_DATA(scal_l),
+						  parameters)
 
-    f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
-    f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
+	f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
+	f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
 
-    s2let_analysis_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
+	s2let_analysis_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
 
-    return f_wav_lmn, f_scal_lm
+	return f_wav_lmn, f_scal_lm
 
 #----------------------------------------------------------------------------------------------------#
 
@@ -829,18 +829,18 @@ def analysis_adjoint_lm2lmn(
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-    J = s2let_j_max(parameters)
+	J = s2let_j_max(parameters)
 
 	scal_l = np.zeros([L,])
-    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-                         <double complex*> np.PyArray_DATA(scal_l),
-                          parameters)
+	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+						 <double complex*> np.PyArray_DATA(scal_l),
+						  parameters)
 
-    flm = np.zeros([L * L,], dtype=complex)
-    s2let_analysis_adjoint_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
+	flm = np.zeros([L * L,], dtype=complex)
+	s2let_analysis_adjoint_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
 
-    return flm
+	return flm
 
 #----------------------------------------------------------------------------------------------------#
 
@@ -861,18 +861,18 @@ def synthesis_lmn2lm(
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-    J = s2let_j_max(parameters)
+	J = s2let_j_max(parameters)
 
 	scal_l = np.zeros([L,])
-    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-                         <double complex*> np.PyArray_DATA(scal_l),
-                          parameters)
+	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+						 <double complex*> np.PyArray_DATA(scal_l),
+						  parameters)
 
-    flm = np.zeros([L * L,], dtype=complex)
-    s2let_synthesis_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
+	flm = np.zeros([L * L,], dtype=complex)
+	s2let_synthesis_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
 
-    return flm
+	return flm
 
 #----------------------------------------------------------------------------------------------------#
 
@@ -891,20 +891,20 @@ def synthesis_adjoint_lm2lmn(np.ndarray[double complex, ndim=1, mode="c"] flm no
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-    J = s2let_j_max(parameters)
-    
+	J = s2let_j_max(parameters)
+	
 	scal_l = np.zeros([L,])
-    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-                         <double complex*> np.PyArray_DATA(scal_l),
-                          parameters)
+	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+						 <double complex*> np.PyArray_DATA(scal_l),
+						  parameters)
 
-    f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
-    f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
+	f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
+	f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
 
-    s2let_synthesis_adjoint_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
+	s2let_synthesis_adjoint_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
 
-    return f_wav_lmn, f_scal_lm
+	return f_wav_lmn, f_scal_lm
 
 #----------------------------------------------------------------------------------------------------#
 

--- a/src/main/pys2let/pys2let.pyx
+++ b/src/main/pys2let/pys2let.pyx
@@ -62,6 +62,9 @@ cdef extern from "s2let/s2let.h":
 	int s2let_n_scal(const s2let_parameters_t *parameters)
 	int s2let_n_wav(const s2let_parameters_t *parameters)
 
+    int s2let_n_lm_scal(const s2let_parameters_t *parameters)
+    int s2let_n_lmn_wav(const s2let_parameters_t *parameters)
+
 	int s2let_n_wav_j(int j, const s2let_parameters_t *parameters)
 
 	void s2let_mw_alm2map(double complex * f, const double complex * flm, int L, int spin)
@@ -205,6 +208,39 @@ cdef extern from "s2let/s2let.h":
 		double complex *f_scal,
 		const double complex *f,
 		const s2let_parameters_t *parameters)
+
+    void s2let_analysis_lm2lmn(
+        double complex *f_wav_lmn,
+        double complex *f_scal_lm,
+        const double complex *flm,
+        const double complex *wav_lm,
+        const double *scal_l,
+        const s2let_parameters_t *parameters)
+
+    void s2let_analysis_adjoint_lmn2lm(
+        double complex *flm,
+        const double complex *f_wav_lmn,
+        const double complex *f_scal_lm,
+        const double complex *wav_lm,
+        const double *scal_l,
+        const s2let_parameters_t *parameters)
+
+    void s2let_synthesis_lmn2lm(
+        double complex *flm,
+        const double complex *f_wav_lmn,
+        const double complex *f_scal_lm,
+        const double complex *wav_lm,
+        const double *scal_l,
+        const s2let_parameters_t *parameters)
+
+    void s2let_synthesis_adjoint_lm2lmn(
+        double complex *f_wav_lmn,
+        double complex *f_scal_lm,
+        const double complex *flm,
+        const double complex *wav_lm,
+        const double *scal_l,
+        const s2let_parameters_t *parameters)
+
 #----------------------------------------------------------------------------------------------------#
 
 cdef extern from "stdlib.h":
@@ -741,6 +777,134 @@ def synthesis_adjoint_px2wav(
 		&parameters)
 
 	return f_wav, f_scal
+
+#----------------------------------------------------------------------------------------------------#
+
+def analysis_lm2lmn(np.ndarray[double complex, ndim=1, mode="c"] flm not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+    J = s2let_j_max(parameters)
+
+	scal_l = np.zeros([L,])
+    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+                         <double complex*> np.PyArray_DATA(scal_l),
+                          parameters)
+
+    f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
+    f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
+
+    s2let_analysis_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
+
+    return f_wav_lmn, f_scal_lm
+
+#----------------------------------------------------------------------------------------------------#
+
+def analysis_adjoint_lm2lmn(
+		np.ndarray[double complex, ndim=1, mode="c"] f_wav_lmn not None,
+		np.ndarray[double complex, ndim=1, mode="c"] f_scal_lm not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+    J = s2let_j_max(parameters)
+
+	scal_l = np.zeros([L,])
+    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+                         <double complex*> np.PyArray_DATA(scal_l),
+                          parameters)
+
+    flm = np.zeros([L * L,], dtype=complex)
+    s2let_analysis_adjoint_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
+
+    return flm
+
+#----------------------------------------------------------------------------------------------------#
+
+def synthesis_lmn2lm(
+		np.ndarray[double complex, ndim=1, mode="c"] f_wav_lmn not None,
+		np.ndarray[double complex, ndim=1, mode="c"] f_scal_lm not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+    J = s2let_j_max(parameters)
+
+	scal_l = np.zeros([L,])
+    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+                         <double complex*> np.PyArray_DATA(scal_l),
+                          parameters)
+
+    flm = np.zeros([L * L,], dtype=complex)
+    s2let_synthesis_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
+
+    return flm
+
+#----------------------------------------------------------------------------------------------------#
+
+def synthesis_adjoint_lm2lmn(np.ndarray[double complex, ndim=1, mode="c"] flm not None,
+		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
+
+	cdef s2let_parameters_t parameters = {}
+	parameters.B = B
+	parameters.L = L
+	parameters.J_min = J_min
+	parameters.N = N
+	parameters.spin = spin
+	parameters.upsample = upsample
+	parameters.sampling_scheme = S2LET_SAMPLING_MW
+	parameters.original_spin = original_spin
+	parameters.dl_method = SSHT_DL_RISBO
+	parameters.reality = 0
+	parameters.verbosity = 0
+    J = s2let_j_max(parameters)
+    
+	scal_l = np.zeros([L,])
+    wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
+    s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
+                         <double complex*> np.PyArray_DATA(scal_l),
+                          parameters)
+
+    f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
+    f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
+
+    s2let_synthesis_adjoint_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
+
+    return f_wav_lmn, f_scal_lm
 
 #----------------------------------------------------------------------------------------------------#
 

--- a/src/main/pys2let/pys2let.pyx
+++ b/src/main/pys2let/pys2let.pyx
@@ -795,24 +795,29 @@ def analysis_lm2lmn(np.ndarray[double complex, ndim=1, mode="c"] flm not None,
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-	J = s2let_j_max(parameters)
+	J = s2let_j_max(&parameters)
 
 	scal_l = np.zeros([L,])
 	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-						 <double complex*> np.PyArray_DATA(scal_l),
-						  parameters)
+	s2let_tiling_wavelet(<double complex*> np.PyArray_DATA(wav_lm),
+						 <double *> np.PyArray_DATA(scal_l),
+						  &parameters)
 
-	f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
-	f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
+	f_wav_lmn = np.zeros([s2let_n_lmn_wav(&parameters),], dtype=complex)
+	f_scal_lm = np.zeros([s2let_n_lm_scal(&parameters),], dtype=complex)
 
-	s2let_analysis_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
-
+	s2let_analysis_lm2lmn(
+		<double complex*> np.PyArray_DATA(f_wav_lmn),
+		<double complex*> np.PyArray_DATA(f_scal_lm),
+		<const double complex*> np.PyArray_DATA(flm),
+		<const double complex*> np.PyArray_DATA(wav_lm),
+		<const double *> np.PyArray_DATA(scal_l),
+		&parameters)
 	return f_wav_lmn, f_scal_lm
 
 #----------------------------------------------------------------------------------------------------#
 
-def analysis_adjoint_lm2lmn(
+def analysis_adjoint_lmn2lm(
 		np.ndarray[double complex, ndim=1, mode="c"] f_wav_lmn not None,
 		np.ndarray[double complex, ndim=1, mode="c"] f_scal_lm not None,
 		B, L, J_min, N, spin, upsample, spin_lowered=False, original_spin=0):
@@ -829,16 +834,22 @@ def analysis_adjoint_lm2lmn(
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-	J = s2let_j_max(parameters)
+	J = s2let_j_max(&parameters)
 
 	scal_l = np.zeros([L,])
 	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-						 <double complex*> np.PyArray_DATA(scal_l),
-						  parameters)
+	s2let_tiling_wavelet(<double complex*> np.PyArray_DATA(wav_lm),
+						 <double *> np.PyArray_DATA(scal_l),
+						  &parameters)
 
 	flm = np.zeros([L * L,], dtype=complex)
-	s2let_analysis_adjoint_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
+	s2let_analysis_adjoint_lmn2lm(
+		<double complex*> np.PyArray_DATA(flm),
+		<const double complex*> np.PyArray_DATA(f_wav_lmn),
+		<const double complex*> np.PyArray_DATA(f_scal_lm),
+		<const double complex*> np.PyArray_DATA(wav_lm),
+		<const double *> np.PyArray_DATA(scal_l),
+		&parameters)
 
 	return flm
 
@@ -861,16 +872,22 @@ def synthesis_lmn2lm(
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-	J = s2let_j_max(parameters)
+	J = s2let_j_max(&parameters)
 
 	scal_l = np.zeros([L,])
 	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-						 <double complex*> np.PyArray_DATA(scal_l),
-						  parameters)
+	s2let_tiling_wavelet(<double complex*> np.PyArray_DATA(wav_lm),
+						 <double *> np.PyArray_DATA(scal_l),
+						  &parameters)
 
 	flm = np.zeros([L * L,], dtype=complex)
-	s2let_synthesis_lmn2lm(flm, f_wav_lmn, f_scal_lm, wav_lm, scal_l, parameters)
+	s2let_synthesis_lmn2lm(
+		<double complex*> np.PyArray_DATA(flm),
+		<const double complex*> np.PyArray_DATA(f_wav_lmn),
+		<const double complex*> np.PyArray_DATA(f_scal_lm),
+		<const double complex*> np.PyArray_DATA(wav_lm),
+		<const double *> np.PyArray_DATA(scal_l),
+		&parameters)
 
 	return flm
 
@@ -891,18 +908,24 @@ def synthesis_adjoint_lm2lmn(np.ndarray[double complex, ndim=1, mode="c"] flm no
 	parameters.dl_method = SSHT_DL_RISBO
 	parameters.reality = 0
 	parameters.verbosity = 0
-	J = s2let_j_max(parameters)
+	J = s2let_j_max(&parameters)
 	
 	scal_l = np.zeros([L,])
 	wav_lm = np.zeros([(J + 1) * L * L,], dtype=complex)
-	s2let_tiling_wavelet(<double *> np.PyArray_DATA(wav_lm),
-						 <double complex*> np.PyArray_DATA(scal_l),
-						  parameters)
+	s2let_tiling_wavelet(<double complex*> np.PyArray_DATA(wav_lm),
+						 <double *> np.PyArray_DATA(scal_l),
+						  &parameters)
 
-	f_wav_lmn = np.zeros([s2let_n_lmn_wav(parameters),], dtype=complex)
-	f_scal_lm = np.zeros([s2let_n_lm_scal(parameters),], dtype=complex)
+	f_wav_lmn = np.zeros([s2let_n_lmn_wav(&parameters),], dtype=complex)
+	f_scal_lm = np.zeros([s2let_n_lm_scal(&parameters),], dtype=complex)
 
-	s2let_synthesis_adjoint_lm2lmn(f_wav_lmn, f_scal_lm, flm, wav_lm, scal_l, parameters)
+	s2let_synthesis_adjoint_lm2lmn(
+		<double complex*> np.PyArray_DATA(f_wav_lmn),
+		<double complex*> np.PyArray_DATA(f_scal_lm),
+		<const double complex*> np.PyArray_DATA(flm),
+		<const double complex*> np.PyArray_DATA(wav_lm),
+		<const double *> np.PyArray_DATA(scal_l),
+		&parameters)
 
 	return f_wav_lmn, f_scal_lm
 

--- a/src/test/python/test_axisym_adjoints.py
+++ b/src/test/python/test_axisym_adjoints.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-from pys2let import 
 import numpy as np
 from pytest import approx, fixture, mark
 
@@ -71,4 +70,9 @@ def test_axisym_adjoint(
     y = wav2px(y_wav, y_scal, B, L, J_min)
     x_wav, x_scal = px2wav(x, B, L, J_min)
 
-    assert y_wav.conj().T @ x_wav + y_scal.conj() @ x_scal == approx(y.conj().T @ x)
+    # y'Ax
+    yAx = y_wav.conj().T @ x_wav + y_scal.conj() @ x_scal
+    # (A'y)'x
+    Ayx = approx(y.conj().T @ x)
+
+    assert yAx == Ayx

--- a/src/test/python/test_axisym_adjoints.py
+++ b/src/test/python/test_axisym_adjoints.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from pys2let import 
 import numpy as np
 from pytest import approx, fixture, mark
 
@@ -12,6 +13,7 @@ from pys2let import (
     synthesis_adjoint_px2wav,
     synthesis_axisym_wav_mw,
     synthesis_wav2px,
+    pys2let_j_max,
 )
 
 
@@ -61,8 +63,6 @@ def random_wavlet_maps(rng, L, spin, nwvlts):
 def test_axisym_adjoint(
     px2wav, wav2px, spin, rng: np.random.Generator, L=10, B=2, J_min=2
 ):
-    from pys2let import pys2let_j_max
-
     nwvlts = pys2let_j_max(B, L, J_min) - J_min + 1
 
     x = random_mw_map(rng, L, spin)

--- a/src/test/python/test_directional_harmonic.py
+++ b/src/test/python/test_directional_harmonic.py
@@ -5,7 +5,7 @@ from pytest import approx, fixture, mark
 
 from pys2let import (
     analysis_lm2lmn,
-    analysis_adjoint_lm2lmn,
+    analysis_adjoint_lmn2lm,
     synthesis_lmn2lm,
     synthesis_adjoint_lm2lmn
 )
@@ -30,11 +30,11 @@ def random_wavlet_lms(rng, L, nwvlts):
     [
         (
             partial(analysis_lm2lmn, spin=0, upsample=1, N=1),
-            partial(analysis_adjoint_lm2lmn, spin=0, upsample=1, N=1),
+            partial(analysis_adjoint_lmn2lm, spin=0, upsample=1, N=1),
         ),
         (
             partial(analysis_lm2lmn, spin=2, upsample=1, N=1),
-            partial(analysis_adjoint_lm2lmn, spin=2, upsample=1, N=1),
+            partial(analysis_adjoint_lmn2lm, spin=2, upsample=1, N=1),
         ),
         (
             partial(synthesis_adjoint_lm2lmn, spin=0, upsample=1, N=1),

--- a/src/test/python/test_directional_harmonic.py
+++ b/src/test/python/test_directional_harmonic.py
@@ -1,0 +1,62 @@
+from functools import partial
+
+import numpy as np
+from pytest import approx, fixture, mark
+
+from pys2let import (
+    analysis_lm2lmn,
+    analysis_adjoint_lm2lmn,
+    synthesis_lmn2lm,
+    synthesis_adjoint_lm2lmn
+)
+
+
+@fixture
+def rng(request):
+    return np.random.default_rng(getattr(request.config.option, "randomly_seed", None))
+
+
+def random_lms(rng, L):
+    return rng.uniform(size=(L * L, 2)) @ [1, 1j]
+
+
+def random_wavlet_lms(rng, L, nwvlts):
+    lms = [random_lms(rng, L) for _ in range(nwvlts + 1)]
+    return lms[0], np.concatenate(lms[1:])
+
+
+@mark.parametrize(
+    "px2wav,wav2px",
+    [
+        (
+            partial(analysis_lm2lmn, spin=0, upsample=1, N=1),
+            partial(analysis_adjoint_lm2lmn, spin=0, upsample=1, N=1),
+        ),
+        (
+            partial(analysis_lm2lmn, spin=2, upsample=1, N=1),
+            partial(analysis_adjoint_lm2lmn, spin=2, upsample=1, N=1),
+        ),
+        (
+            partial(synthesis_adjoint_lm2lmn, spin=0, upsample=1, N=1),
+            partial(synthesis_lmn2lm, spin=0, upsample=1, N=1),
+        ),
+        (
+            partial(synthesis_adjoint_lm2lmn, spin=2, upsample=1, N=1),
+            partial(synthesis_lmn2lm, spin=2, upsample=1, N=1),
+        ),
+    ],
+)
+def test_axisym_adjoint(
+    px2wav, wav2px, rng: np.random.Generator, L=10, B=2, J_min=2
+):
+    from pys2let import pys2let_j_max
+
+    nwvlts = pys2let_j_max(B, L, J_min) - J_min + 1
+
+    x = random_lms(rng, L)
+    y_scal, y_wav = random_wavlet_lms(rng, L, nwvlts)
+
+    y = wav2px(y_wav, y_scal, B, L, J_min)
+    x_wav, x_scal = px2wav(x, B, L, J_min)
+
+    assert y_wav.conj().T @ x_wav + y_scal.conj() @ x_scal == approx(y.conj().T @ x)

--- a/src/test/python/test_directional_harmonic.py
+++ b/src/test/python/test_directional_harmonic.py
@@ -7,7 +7,8 @@ from pys2let import (
     analysis_lm2lmn,
     analysis_adjoint_lmn2lm,
     synthesis_lmn2lm,
-    synthesis_adjoint_lm2lmn
+    synthesis_adjoint_lm2lmn,
+    pys2let_j_max,
 )
 
 
@@ -49,8 +50,6 @@ def random_wavlet_lms(rng, L, nwvlts):
 def test_axisym_adjoint(
     px2wav, wav2px, rng: np.random.Generator, L=10, B=2, J_min=2
 ):
-    from pys2let import pys2let_j_max
-
     nwvlts = pys2let_j_max(B, L, J_min) - J_min + 1
 
     x = random_lms(rng, L)

--- a/src/test/python/test_directional_harmonic.py
+++ b/src/test/python/test_directional_harmonic.py
@@ -58,4 +58,9 @@ def test_axisym_adjoint(
     y = wav2px(y_wav, y_scal, B, L, J_min)
     x_wav, x_scal = px2wav(x, B, L, J_min)
 
-    assert y_wav.conj().T @ x_wav + y_scal.conj() @ x_scal == approx(y.conj().T @ x)
+    # y'Ax
+    yAx = y_wav.conj().T @ x_wav + y_scal.conj() @ x_scal
+    # (A'y)'x
+    Ayx = approx(y.conj().T @ x)
+
+    assert yAx == Ayx


### PR DESCRIPTION
Carrying on from #22.  Python wrappers for the wavelet transforms and adjoints in harmonic space.  So far only had wrappers for the pixel space transforms.  This goes some way towards #20 